### PR TITLE
Test addition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
+dist: bionic
+
 language: php
 
 php:
   - 7.2
-  - 7.3
 
-sudo: false
+addons:
+  mariadb: "10.2"
 
-install:
-  - travis_retry composer install --no-interaction
+cache:
+  directories:
+    - vendor
 
-script:
-  - vendor/bin/phpunit --coverage-clover clover.xml
+before_script:
+  - cp .env.travis .env
+  - sudo mysql -e 'CREATE DATABASE testing;'
+  - composer self-update
+  - composer install --no-interaction
+  - php artisan migrate --no-interaction -vvv
 
-after_script:
-- bash <(curl -s https://codecov.io/bash)
+script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
-dist: bionic
-
 language: php
 
 php:
   - 7.2
+  - 7.3
 
-addons:
-  mariadb: "10.2"
+sudo: false
 
-cache:
-  directories:
-    - vendor
+install:
+  - travis_retry composer install --no-interaction
 
-before_script:
-  - cp .env.travis .env
-  - sudo mysql -e 'CREATE DATABASE testing;'
-  - composer self-update
-  - composer install --no-interaction
-  - php artisan migrate --no-interaction -vvv
+script:
+  - vendor/bin/phpunit --coverage-clover clover.xml
 
-script: vendor/bin/phpunit
+after_script:
+- bash <(curl -s https://codecov.io/bash)

--- a/app/Author.php
+++ b/app/Author.php
@@ -18,6 +18,6 @@ class Author extends Model
 
     public function user()
     {
-        return $this->hasOne('App\User');
+        return $this->belongsTo('App\User');
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -91,6 +91,12 @@ return [
             'prefix_indexes' => true,
         ],
 
+        'sqlite_testing' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
+
     ],
 
     /*

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 
 $factory->define(Category::class, function (Faker $faker) {
     return [
-        'name' => 'Category name',
+        'name' => $faker->word(),
         'type' => 'learn',
     ];
 });

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,7 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="sqlite_testing"/>
         <server name="MAIL_DRIVER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,6 +27,7 @@
     </extensions>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <server name="APP_KEY" value="base64:O0YaRJV5D7twpbzuv874iLweBiIqnUEOX/AAebP6V0Q="/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="sqlite_testing"/>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Cyberfusion Knowledgebase [![Build Status](https://travis-ci.org/namelivia/Knowledgebase.svg?branch=master)](https://travis-ci.org/namelivia/Knowledgebase) [![codecov](https://codecov.io/gh/namelivia/Knowledgebase/branch/master/graph/badge.svg)](https://codecov.io/gh/namelivia/Knowledgebase)
+# Cyberfusion Knowledgebase [![Build Status](https://travis-ci.org/CyberfusionNL/Knowledgebase.svg?branch=master)](https://travis-ci.org/CyberfusionNL/Knowledgebase) [![codecov](https://codecov.io/gh/CyberfusionNL/Knowledgebase/branch/master/graph/badge.svg)](https://codecov.io/gh/CyberfusionNL/Knowledgebase)
 
 This knowledgebase is used, built and maintained by Cyberfusion.
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Cyberfusion Knowledgebase
+# Cyberfusion Knowledgebase[![Build Status](https://travis-ci.org/namelivia/Knowledgebase.svg?branch=master)](https://travis-ci.org/namelivia/Knowledgebase) [![codecov](https://codecov.io/gh/namelivia/Knowledgebase/branch/master/graph/badge.svg)](https://codecov.io/gh/namelivia/Knowledgebase)
 
 This knowledgebase is used, built and maintained by Cyberfusion.
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Cyberfusion Knowledgebase[![Build Status](https://travis-ci.org/namelivia/Knowledgebase.svg?branch=master)](https://travis-ci.org/namelivia/Knowledgebase) [![codecov](https://codecov.io/gh/namelivia/Knowledgebase/branch/master/graph/badge.svg)](https://codecov.io/gh/namelivia/Knowledgebase)
+# Cyberfusion Knowledgebase [![Build Status](https://travis-ci.org/namelivia/Knowledgebase.svg?branch=master)](https://travis-ci.org/namelivia/Knowledgebase) [![codecov](https://codecov.io/gh/namelivia/Knowledgebase/branch/master/graph/badge.svg)](https://codecov.io/gh/namelivia/Knowledgebase)
 
 This knowledgebase is used, built and maintained by Cyberfusion.
 

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Article;
+use App\Author;
+use App\Category;
+use App\User;
+use Tests\TestCase;
+
+class ArticleTest extends TestCase
+{
+    private $article;
+    private $author;
+    private $category;
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->author = factory(Author::class)->create([
+            'user_id' => $this->user->id,
+        ]);
+        $this->category = factory(Category::class)->create([
+            'name' => 'foobar',
+        ]);
+        $this->article = factory(Article::class)->create([
+            'author_id' => $this->author->id,
+            'category_id' => $this->category->id,
+            'type' => 'learn',
+        ]);
+    }
+
+    public function testGetAuthor()
+    {
+        $this->assertEquals(
+            $this->author->id,
+            $this->article->author->first()->id
+        );
+    }
+
+    public function testGetAuthorAttribute()
+    {
+        $this->assertEquals(
+            $this->author->id,
+            $this->article->getAuthorAttribute()->first()->id
+        );
+    }
+
+    public function testGetCategory()
+    {
+        $this->assertEquals(
+            $this->category->id,
+            $this->article->category()->first()->id
+        );
+    }
+}

--- a/tests/Feature/AuthorTest.php
+++ b/tests/Feature/AuthorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Author;
+use App\User;
+use Tests\TestCase;
+
+class AuthorTest extends TestCase
+{
+    private $author;
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->author = factory(Author::class)->create([
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    public function testGetUser()
+    {
+        $this->assertEquals(
+            $this->user->id,
+            $this->author->user->first()->id
+        );
+    }
+
+    public function testGetUserAttribute()
+    {
+        $this->assertEquals(
+            $this->user->id,
+            $this->author->getUserAttribute()->first()->id
+        );
+    }
+}

--- a/tests/Feature/CategoryTest.php
+++ b/tests/Feature/CategoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Category;
 use App\Article;
 use Tests\TestCase;

--- a/tests/Feature/CategoryTest.php
+++ b/tests/Feature/CategoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Category;
+use App\Article;
+use Tests\TestCase;
+
+class CategoryTest extends TestCase
+{
+    private $category;
+    private $parent;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->parent = factory(Category::class)->create();
+        $this->category = factory(Category::class)->create([
+            'parent_id' => $this->parent->id,
+        ]);
+    }
+
+    public function testGetArticles()
+    {
+        $articles = factory(Article::class, 3)->create([
+            'author_id' => 1,
+            'category_id' => $this->category->id,
+            'type' => 'learn',
+        ]);
+
+        $this->assertEquals(
+            $articles->pluck('id'),
+            $this->category->articles->pluck('id')
+        );
+    }
+
+    public function testGetParent()
+    {
+        $this->assertEquals($this->parent->id, $this->category->parent->id);
+    }
+
+    public function testGetPublicArticles()
+    {
+        $private = factory(Article::class)->create([
+            'author_id' => 1,
+            'category_id' => $this->category->id,
+            'type' => 'learn',
+            'state' => Article::DRAFT,
+        ]);
+
+        $public = factory(Article::class)->create([
+            'author_id' => 1,
+            'category_id' => $this->category->id,
+            'type' => 'learn',
+            'state' => Article::PUBLISHED,
+        ]);
+
+        $this->assertEquals(
+            [$public->id],
+            $this->category->public_articles->pluck('id')->all()
+        );
+    }
+}

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Author;
+use App\User;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    private $author;
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->author = factory(Author::class)->create([
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    public function testGetAuthor()
+    {
+        $this->assertEquals(
+            $this->author->id,
+            $this->user->author->first()->id
+        );
+    }
+
+    public function testSettingAndRetrievingTheTwoFactorSecret()
+    {
+        $secret = 'foobar';
+        $this->user->twofactor_secret = $secret;
+        $this->assertEquals(
+            $secret,
+            $this->user->twofactor_secret
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,9 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication;
+    use CreatesApplication, RefreshDatabase;
 }


### PR DESCRIPTION
As requested in #7 I've added tests for all the models (Category, Author, User and Article) raising the test coverage from 7.45% up to 16.15%. I've also added badges on the readme for both travisCI (build status) and codecov (test coverage).
After the PR gets merged I plan to increase the test coverage even more on subsequent PR's before closing the issue gets closed.