### PR TITLE
Adds a travis file with also codecov and no database configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
-dist: bionic
-
 language: php
 
 php:
   - 7.2
+  - 7.3
 
-addons:
-  mariadb: "10.2"
+sudo: false
 
-cache:
-  directories:
-    - vendor
+install:
+  - travis_retry composer install --no-interaction
 
-before_script:
-  - cp .env.travis .env
-  - sudo mysql -e 'CREATE DATABASE testing;'
-  - composer self-update
-  - composer install --no-interaction
-  - php artisan migrate --no-interaction -vvv
+script:
+  - vendor/bin/phpunit --coverage-clover clover.xml
 
-script: vendor/bin/phpunit
+after_script:
+- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
It would close #13 this travis configuration file avoids running a mysql database and run the tests on a sqlite memory db. Also comes with codecov test coverage report generation to monitor the tests coverage.